### PR TITLE
handle large output in llm client with chunking

### DIFF
--- a/agent/workflow/output.py
+++ b/agent/workflow/output.py
@@ -31,7 +31,8 @@ def execute_command(command_parts, llm_client, base_dir, layer):
     os.makedirs(os.path.join(base_dir, "logs"), exist_ok=True)
 
     timestamp = datetime.utcnow().isoformat()
-    output_file = os.path.join(base_dir, "logs", f"{tool}_{uuid.uuid4().hex[:8]}.txt")
+    output_file = os.path.join(
+        base_dir, "logs", f"{tool}_{uuid.uuid4().hex[:8]}.txt")
     metadata_file = os.path.join(base_dir, "metadata.json")
 
     start_time = time.time()
@@ -49,7 +50,9 @@ def execute_command(command_parts, llm_client, base_dir, layer):
             for line in process.stdout:
                 out.write(line)
                 last_line = line.strip()
-                print(f"\r    {last_line[:term_width - 4]}", end="", flush=True)
+                print(f"\r    {' '*(term_width-4)}", end="", flush=True)
+                print(
+                    f"\r    {last_line[:term_width - 4]}", end="", flush=True)
 
             print()  # newline after command completes
             process.wait(timeout=300)

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 llm:
   provider: groq         # Options: ollama, openai, groq, etc.
   model: meta-llama/llama-4-scout-17b-16e-instruct
-  context_length: 60000    # Some models support higher limits
+  context_length: 2000    # Some models support higher limits
 
 ollama:
   host: http://host.docker.internal:11434


### PR DESCRIPTION
### Summary

This PR introduces proper context-aware chunked summarization for both tool output analysis (`post_step`) and executive summary generation (`executive_summary`). It replaces the previous unsafe approach of concatenating large outputs into a single prompt — which often led to LLM truncation or invalid JSON.

### What's Changed

#### 🧠 post_step()
- Checks if command output exceeds LLM context length
- Falls back to chunked summarization using `_build_prompt_post_step_chunked()`
- Each chunk includes the previous summary for progressive refinement
- Final output is guaranteed structured JSON with keys:
  - `summary`
  - `recommended_steps`
  - `services_found`

#### 📊 executive_summary()
- Combines `summary.md` and `exploits.txt`
- If content exceeds context, performs iterative summarization via `_build_prompt_exec_summary_chunked()`
- Maintains clean Markdown output

### Why This Matters

Previously, the system naively concatenated long inputs and submitted them to the LLM in one go. This:
- Exceeded context limits
- Caused malformed or truncated responses
- Often broke JSON parsing

This PR solves that by introducing a scalable, chunk-based summarization strategy that works reliably for large recon tasks.

### Extras
- Added a blue-colored `[ * ] Preparing Executive Summary...` log for clarity
- Reused `_chunk_text_by_tokens()` for consistency and maintainability

solves #32 