### PR TITLE
Refactor: Remove --hostname flag and derive domain from --hosts file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,13 +32,16 @@ RUN pip3 install --break-system-packages --no-cache-dir -r /tmp/requirements.txt
     rm /tmp/requirements.txt && \
     python3 /tmp/setup.py
 
-# Copy agent code and entrypoint
+# Copy agent code and configs
 COPY agent/ /opt/agent/
 COPY tests/ /opt/agent/tests/
 COPY tools.yaml /opt/agent/
 COPY filter.yaml /opt/agent/
 COPY config.yaml /opt/agent/config.yaml
+
+# Copy entrypoint and make executable
 COPY entrypoint.sh /opt/entrypoint.sh
 RUN chmod +x /opt/entrypoint.sh
 
+# Use the custom entrypoint that appends CUSTOM_HOSTS_FILE to /etc/hosts
 ENTRYPOINT ["/opt/entrypoint.sh"]


### PR DESCRIPTION
## Summary

This PR addresses [#ISSUE_NUMBER] by removing the `--hostname` / `MACHINE_NAME` logic entirely and replacing it with a more robust, file-based approach using the `--hosts` flag as the single source of truth.

---

## Changes Introduced

### ✅ `hawx.sh`
- Removed all references to `--hostname` and `MACHINE_NAME`
- Simplified CLI help message
- Now only accepts domain mappings through the `--hosts` file
- Mounts the provided hosts file into the container and sets the `CUSTOM_HOSTS_FILE` environment variable

### ✅ `entrypoint.sh`
- Removed the logic that manually appended `$MACHINE_NAME.htb` to `/etc/hosts`
- Now resolves the domain name corresponding to `$TARGET_IP` by parsing `CUSTOM_HOSTS_FILE`
- If found, the domain (e.g., `dog.htb`) is passed to `main.py` as `RESOLVED_TARGET`
- If not found, falls back to using the raw IP

---

## Benefits

- ✅ Eliminates duplicated CLI input (`--hostname`)
- ✅ Ensures consistency between what's in `/etc/hosts` and what's used in recon
- ✅ Enables domain-aware tools like `ffuf`, `curl`, `whatweb`, etc., to function correctly with `Host` headers
- ✅ Clean separation of responsibilities: `entrypoint.sh` handles resolution; `main.py` stays focused on recon logic

---

## Testing

- Verified container builds cleanly with `--hosts` and without `--hostname`
- Verified that `/etc/hosts` contains injected domains from mounted file
- Verified that domain name is correctly extracted and passed to `main.py`
- Verified fallback behavior to raw IP when no domain match is found

---

## Follow-Up

- Optionally update `main.py` to print both the IP and resolved domain in the summary
- Consider auto-enabling vhost enumeration when a domain is present

Closes #42 
