### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,5 +1,8 @@
 name: Pylint
 
+permissions:
+  contents: read
+
 on: [push]
 
 env:


### PR DESCRIPTION
Potential fix for [https://github.com/jackhax/Hawx-Recon-Agent/security/code-scanning/2](https://github.com/jackhax/Hawx-Recon-Agent/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will explicitly define the permissions required for the workflow, ensuring that the `GITHUB_TOKEN` has only the necessary access. Since the workflow only needs to read repository contents (e.g., to access the code for analysis), the permissions should be set to `contents: read`.

The changes will be made to the `.github/workflows/pylint.yml` file by adding the `permissions` key at the top level, just below the `name` field.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
